### PR TITLE
chore: add django 4.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.2.*", "6.0.*"]
+        django-version: ["4.2.*", "5.2.*", "6.0.*"]
         exclude:
           - python-version: "3.10"
             django-version: "6.0.*"

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@
 # Supported test environments as python:django pairs. Keep this explicit so
 # unsupported combinations, such as Django 6 on Python < 3.12, are not run.
 TEST_MATRIX ?= \
+	'3.10:4.2.*' \
 	'3.10:5.2.*' \
+	'3.11:4.2.*' \
 	'3.11:5.2.*' \
+	'3.12:4.2.*' \
 	'3.12:5.2.*' \
 	'3.12:6.0.*' \
 	'3.13:5.2.*' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Web Environment",
   "Framework :: Django",
+  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "License :: OSI Approved :: MIT License",
@@ -28,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "Django>=5.2",
+  "Django>=4.2",
   "attrs>=26.1.0",
   "djangorestframework>=3.17.1",
   "requests>=2.34.0",

--- a/uv.lock
+++ b/uv.lock
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "django-postcode-lookup"
-version = "1.0.1"
+version = "2.0.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -304,7 +304,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=26.1.0" },
-    { name = "django", specifier = ">=5.2" },
+    { name = "django", specifier = ">=4.2" },
     { name = "djangorestframework", specifier = ">=3.17.1" },
     { name = "requests", specifier = ">=2.34.0" },
 ]


### PR DESCRIPTION
For a easier upgrade path to Django 5.2, we need to add support for Django 4.2
first.
